### PR TITLE
Add a way to set the runtime include excludes fileset from the task. …

### DIFF
--- a/src/com/inet/gradle/setup/dmg/DmgBuilder.java
+++ b/src/com/inet/gradle/setup/dmg/DmgBuilder.java
@@ -198,6 +198,23 @@ public class DmgBuilder extends AbstractBuilder<Dmg> {
         task.getProject().getLogger().lifecycle( "\tbundle JRE: " + jreDir );
         FileSet fileSet = new FileSet();
         fileSet.setDir( jreDir );
+        
+        fileSet.appendIncludes(new String[] {
+                "jre/*",
+                "jre/lib/",
+                "jre/bin/java"
+        });
+
+        fileSet.appendExcludes(new String[] {
+            "jre/lib/deploy/",
+            "jre/lib/deploy.jar",
+            "jre/lib/javaws.jar",
+            "jre/lib/libdeploy.dylib",
+            "jre/lib/libnpjp2.dylib",
+            "jre/lib/plugin.jar",
+            "jre/lib/security/javaws.policy"
+        });
+
         appBundler.addConfiguredRuntime( fileSet );
     }
 

--- a/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/src/com/oracle/appbundler/AppBundlerTask.java
@@ -200,6 +200,11 @@ public class AppBundlerTask extends Task {
 
         this.runtime = runtime;
 
+        // If Patterns are already set up, do not do again.
+        if ( runtime.hasPatterns() ) {
+        	return;
+        }
+        
         runtime.appendIncludes(new String[] {
             "jre/",
         });


### PR DESCRIPTION
…If there are already patterns defined, do not let the AppBundlerTask do this.