### PR TITLE
Refactoring. Get rid of redundant information.

### DIFF
--- a/src/com/inet/gradle/setup/AbstractSetupTask.java
+++ b/src/com/inet/gradle/setup/AbstractSetupTask.java
@@ -208,7 +208,7 @@ public abstract class AbstractSetupTask extends DefaultTask implements SetupSour
     @OutputFile
     public File getSetupFile() {
         SetupBuilder setup = getSetupBuilder();
-        return new File( setup.getDestinationDir(), setup.getSetupName() + "." + getExtension() );
+        return new File( setup.getDestinationDir(), setup.getDownloadFileName() + "." + getExtension() );
     }
 
     /**

--- a/src/com/inet/gradle/setup/Application.java
+++ b/src/com/inet/gradle/setup/Application.java
@@ -3,7 +3,7 @@ package com.inet.gradle.setup;
 
 public class Application {
 	protected final SetupBuilder			setup;
-	private String 							name, baseName, displayName, mainJar, mainClass, executable, description, workDir;
+	private String 							displayName, mainJar, mainClass, executable, description, workDir;
 	private Object icons;
 
 	/**
@@ -15,46 +15,6 @@ public class Application {
     }
 
     /**
-     * Returns the name of this starter.
-     * @return the name of this starter
-     */
-    public String getName() {
-        if( name != null ) {
-            return name;
-        }
-        return setup.getBaseName();
-    }
-
-    /**
-     * Set the name of the application.
-     * @param name the name to set
-     */
-    public void setName( String name ) {
-        this.name = name;
-    }
-    
-    /**
-     * Get the baseName for the application
-     * @return the base name
-     */
-    public String getBaseName() {
-        if( baseName != null ) {
-            return baseName;
-        }
-        return setup.getBaseName();
-    }
-
-    /**
-     * Set the base name of the service name. Can contains slashes if it should be in a sub directory. This change the
-     * working directory of the service. On Windows ".exe" is added for the file name of the service.
-     * 
-     * @param baseName the new baseName
-     */
-    public void setBaseName( String baseName ) {
-        this.baseName = baseName;
-    }
-
-    /**
      * get the displayName of the application.
      * @return the display name
      */
@@ -62,7 +22,7 @@ public class Application {
         if( displayName != null ) {
             return displayName;
         }
-        return getName();
+        return setup.getApplication();
 	}
 
     /**
@@ -97,7 +57,10 @@ public class Application {
      * @return the executable
      */
     public String getExecutable() {
-        return executable;
+    	if ( executable != null ) {
+    		return executable;
+    	}
+    	return setup.getAppIdentifier();
     }
 
     /**

--- a/src/com/inet/gradle/setup/Service.java
+++ b/src/com/inet/gradle/setup/Service.java
@@ -5,7 +5,7 @@ package com.inet.gradle.setup;
  */
 public class Service extends Application {
     private boolean startOnBoot = true;
-    private String  startArguments;
+    private String  startArguments, serviceID;
 
     /**
      * Create a new Service
@@ -13,17 +13,6 @@ public class Service extends Application {
      */
     public Service( SetupBuilder setup ) {
         super( setup );
-    }
-
-    /**
-     * Get the baseName for the service
-     * @return the base name
-     */
-    public String getBaseName() {
-        if( !super.getBaseName().equals( getName() ) ) {
-            return super.getBaseName();
-        }
-        return getName() + " Service";
     }
 
     /**
@@ -60,4 +49,26 @@ public class Service extends Application {
     public void setStartArguments( String startArguments ) {
         this.startArguments = startArguments;
     }
+
+    /**
+     * Returns the serviceID which should be a short version of the application name 
+     * @return the serviceID
+     */
+	public String getServiceID() {
+		String id = serviceID;
+        if( id == null ) {
+			id = setup.getAppIdentifier() + "-service";
+        }
+        
+        return id.toLowerCase().replace( ' ', '-' );
+	}
+
+	/**
+	 * Set the serviceID which should be a short version of the application name
+	 * It must not contain spaces.
+	 * @param serviceID
+	 */
+	public void setServiceID(String serviceID) {
+		this.serviceID = serviceID;
+	}
 }

--- a/src/com/inet/gradle/setup/SetupBuilder.java
+++ b/src/com/inet/gradle/setup/SetupBuilder.java
@@ -49,9 +49,9 @@ public class SetupBuilder implements SetupSources {
 
     private String                 description;
 
-    private String                 baseName;
+    private String                 appIdentifier;
 
-    private String                 setupName;
+    private String                 downloadFileName;
 
     private Object                 licenseFile;
 
@@ -190,13 +190,14 @@ public class SetupBuilder implements SetupSources {
     }
 
     /**
-     * Get the base name of the setup file. If not set then the project.archivesBaseName is used.
+     * Get the short application identifier of the setup file. If not set then the project.archivesBaseName is used.
+     * Should not contain spaces if possible.
      * 
-     * @return the base name
+     * @return the application identifier
      */
-    public String getBaseName() {
-        if( baseName != null ) {
-            return baseName;
+    public String getAppIdentifier() {
+        if( appIdentifier != null ) {
+            return appIdentifier;
         }
         Object name = project.getProperties().get( "archivesBaseName" );
         if( name != null ) {
@@ -206,11 +207,11 @@ public class SetupBuilder implements SetupSources {
     }
 
     /**
-     * Set the base name for the setup file.
-     * @param baseName new base name
+     * Set the short application identifier for the setup file.
+     * @param identifier new base name
      */
-    public void setBaseName( String baseName ) {
-        this.baseName = baseName;
+    public void setAppIdentifier( String identifier ) {
+        this.appIdentifier = identifier;
     }
 
     /**
@@ -218,15 +219,19 @@ public class SetupBuilder implements SetupSources {
      * 
      * @return the setup file name
      */
-    public String getSetupName() {
-        if( setupName != null ) {
-            return setupName;
+    public String getDownloadFileName() {
+        if( downloadFileName != null ) {
+            return downloadFileName;
         }
-        return getBaseName() + '-' + getVersion();
+        return getAppIdentifier() + '-' + getVersion();
     }
 
-    public void setSetupName( String setupName ) {
-        this.setupName = setupName;
+    /**
+     * Set the name of the download file for the setup. This should contain the version if needed
+     * @param setupName name of the setup
+     */
+    public void setDownloadFileName( String setupName ) {
+        this.downloadFileName = setupName;
     }
 
     public File getLicenseFile() {

--- a/src/com/inet/gradle/setup/deb/DebBuilder.java
+++ b/src/com/inet/gradle/setup/deb/DebBuilder.java
@@ -104,7 +104,7 @@ public class DebBuilder extends AbstractBuilder<Deb> {
             
             controlBuilder.build();
 
-            documentBuilder = new DebDocumentFileBuilder( super.task, setup, new File( buildDir, "/usr/share/doc/" + setup.getBaseName() ) );
+            documentBuilder = new DebDocumentFileBuilder( super.task, setup, new File( buildDir, "/usr/share/doc/" + setup.getAppIdentifier() ) );
             documentBuilder.build();
 
             changeDirectoryPermissionsTo755( buildDir );
@@ -122,9 +122,9 @@ public class DebBuilder extends AbstractBuilder<Deb> {
 
 
     private void setupEula() throws IOException {
-        String templateLicenseName = setup.getBaseName()+"/license";
-        String templateAcceptName = setup.getBaseName()+"/accept-license";
-        String templateErrorName = setup.getBaseName()+"/error-license";
+        String templateLicenseName = setup.getAppIdentifier()+"/license";
+        String templateAcceptName = setup.getAppIdentifier()+"/accept-license";
+        String templateErrorName = setup.getAppIdentifier()+"/error-license";
         try (FileWriter fw = new FileWriter( createFile( "DEBIAN/templates", false ) );
              BufferedReader fr = new BufferedReader( new FileReader( setup.getLicenseFile() ) )) {
             fw.write( "Template: " + templateLicenseName + "\n" );
@@ -192,7 +192,7 @@ public class DebBuilder extends AbstractBuilder<Deb> {
         if(starter != null ) {
         	workingDir = starter.getWorkDir();
         }
-        String serviceUnixName = service.getName().toLowerCase().replace( ' ', '-' );
+        String serviceUnixName = service.getServiceID();
         String installationRoot = task.getInstallationRoot();
         String mainJarPath;
         Template initScript = new Template( "deb/template/init-service.sh" );
@@ -229,7 +229,7 @@ public class DebBuilder extends AbstractBuilder<Deb> {
      * @throws IOException on errors during creating or writing a file
      */
     private void setupStarter( DesktopStarter starter ) throws IOException {
-        String unixName = starter.getName().toLowerCase().replace( ' ', '-' );
+        String unixName = starter.getExecutable();
         String consoleStarterPath = "usr/bin/" + unixName;
         try (FileWriter fw = new FileWriter( createFile( consoleStarterPath, true ) )) {
             fw.write( "#!/bin/bash\n" );
@@ -250,7 +250,7 @@ public class DebBuilder extends AbstractBuilder<Deb> {
         }
         try (FileWriter fw = new FileWriter( createFile( "usr/share/applications/" + unixName + ".desktop", false ) )) {
             fw.write( "[Desktop Entry]\n" );
-            fw.write( "Name=" + starter.getName() + "\n" );
+            fw.write( "Name=" + starter.getDisplayName() + "\n" );
             fw.write( "Comment=" + starter.getDescription().replace( '\n', ' ' ) + "\n" );
             fw.write( "Exec=/" + consoleStarterPath + " %F\n" );
             fw.write( "Icon=" + unixName + "\n" );
@@ -264,7 +264,6 @@ public class DebBuilder extends AbstractBuilder<Deb> {
                 fw.write( "Categories=" + starter.getCategories() + "\n" );
             }
         }
-        
     }
 
     /**
@@ -294,7 +293,7 @@ public class DebBuilder extends AbstractBuilder<Deb> {
             ArrayList<String> command = new ArrayList<>();
             command.add( "lintian" );
             //    		command.add( "-d" );
-            command.add( setup.getDestinationDir().getAbsolutePath() + "/" + setup.getSetupName() + "." + task.getExtension() );
+            command.add( setup.getDestinationDir().getAbsolutePath() + "/" + setup.getDownloadFileName() + "." + task.getExtension() );
             exec( command );
         }
     }
@@ -308,7 +307,7 @@ public class DebBuilder extends AbstractBuilder<Deb> {
         command.add( "dpkg-deb" );
         command.add( "--build" );
         command.add( buildDir.getAbsolutePath() );
-        command.add( setup.getDestinationDir().getAbsolutePath() + "/" + setup.getSetupName() + "." + task.getExtension() );
+        command.add( setup.getDestinationDir().getAbsolutePath() + "/" + setup.getDownloadFileName() + "." + task.getExtension() );
         exec( command );
     }
 

--- a/src/com/inet/gradle/setup/deb/DebControlFileBuilder.java
+++ b/src/com/inet/gradle/setup/deb/DebControlFileBuilder.java
@@ -296,7 +296,7 @@ class DebControlFileBuilder {
 	 */
 	private void putPackage(OutputStreamWriter controlWriter)
 			throws IOException {
-		String packages = setup.getBaseName();
+		String packages = setup.getAppIdentifier();
 		if(packages == null || packages.length() == 0) {
 			throw new RuntimeException("No package declared in the setup configuration.");
 		} else {

--- a/src/com/inet/gradle/setup/deb/DebDocumentFileBuilder.java
+++ b/src/com/inet/gradle/setup/deb/DebDocumentFileBuilder.java
@@ -126,7 +126,7 @@ class DebDocumentFileBuilder {
 			
 			controlWriter = new OutputStreamWriter(gzipstream, "UTF-8");
 		 
-			controlWriter.write( setup.getBaseName() + " (" + setup.getVersion() + ") unstable; urgency=low" + NEWLINE + NEWLINE);
+			controlWriter.write( setup.getAppIdentifier() + " (" + setup.getVersion() + ") unstable; urgency=low" + NEWLINE + NEWLINE);
 			
 			
 			String changes = deb.getChanges();

--- a/src/com/inet/gradle/setup/dmg/DmgBuilder.java
+++ b/src/com/inet/gradle/setup/dmg/DmgBuilder.java
@@ -86,8 +86,8 @@ public class DmgBuilder extends AbstractBuilder<Dmg> {
         		applicationBuilder.buildApplication( application );
 			}
 
-            title = setup.getSetupName();
-            applicationName = setup.getBaseName();
+            title = setup.getDownloadFileName();
+            applicationName = setup.getAppIdentifier();
             // applicationName = setup.getApplication();
             imageSourceRoot = buildDir.toString() + "/" + setup.getApplication() + ".app";
             iconFile = applicationBuilder.getApplicationIcon();
@@ -159,7 +159,7 @@ public class DmgBuilder extends AbstractBuilder<Dmg> {
             String script = new String( bos.toByteArray(), StandardCharsets.UTF_8 );
             script = script.replace( "${serviceName}", launchdScriptName );
             script = script.replace( "${applicationName}", applicationName );
-            script = script.replace( "${programName}", "/Library/" + applicationName + "/" + applicationName + ".app/Contents/MacOS/" + setup.getBaseName() );
+            script = script.replace( "${programName}", "/Library/" + applicationName + "/" + applicationName + ".app/Contents/MacOS/" + setup.getAppIdentifier() );
             script = script.replace( "${installName}", "/Library/" + applicationName + "/" + applicationName + ".app" );
 
             DesktopStarter runAfter = setup.getRunAfter();

--- a/src/com/inet/gradle/setup/dmg/OSXApplicationBuilder.java
+++ b/src/com/inet/gradle/setup/dmg/OSXApplicationBuilder.java
@@ -88,7 +88,7 @@ public class OSXApplicationBuilder extends AbstractBuilder<Dmg> {
 
 		public PreparedAppBundlerTask prepare() throws Exception {
 			appBundler.setOutputDirectory(buildDir);
-			appBundler.setName(application.getName());
+			appBundler.setName(application.getDisplayName());
 			appBundler.setDisplayName(application.getDisplayName());
 
 			String version = setup.getVersion();
@@ -102,7 +102,7 @@ public class OSXApplicationBuilder extends AbstractBuilder<Dmg> {
 			}
 			appBundler.setShortVersion(version);
 
-			appBundler.setExecutableName(application.getBaseName());
+			appBundler.setExecutableName(application.getExecutable());
 			appBundler.setIdentifier(application.getMainClass());
 			appBundler.setMainClassName(application.getMainClass());
 			appBundler.setJarLauncherName(application.getMainJar());
@@ -198,7 +198,6 @@ public class OSXApplicationBuilder extends AbstractBuilder<Dmg> {
 	 */
 	private void createPreferencePane( Service service ) throws Throwable {
 
-		String applicationName = service.getName();
 		String displayName = service.getDisplayName();
 
 		// Unpack
@@ -209,23 +208,23 @@ public class OSXApplicationBuilder extends AbstractBuilder<Dmg> {
         input.close();
         output.close();
 
-		File resourcesOutput = new File(buildDir, applicationName  + ".app/Contents/Resources");
+		File resourcesOutput = new File(buildDir, displayName  + ".app/Contents/Resources");
         ResourceUtils.unZipIt(setPrefpane, resourcesOutput);
 
 		// Rename to app-name
-        File prefPaneLocation = new File(resourcesOutput, applicationName + ".prefPane");
+        File prefPaneLocation = new File(resourcesOutput, displayName + ".prefPane");
 
         // rename helper Tool
         File prefPaneContents = new File(resourcesOutput, "SetupBuilderOSXPrefPane.prefPane/Contents");
 		Path iconPath = getApplicationIcon().toPath();
 
 		Files.copy(iconPath, new File(prefPaneContents, "Resources/SetupBuilderOSXPrefPane.app/Contents/Resources/applet.icns").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-		Files.move(new File(prefPaneContents, "MacOS/SetupBuilderOSXPrefPane").toPath(), new File( prefPaneContents, "MacOS/"+ applicationName ).toPath(),  java.nio.file.StandardCopyOption.REPLACE_EXISTING );
-		Files.move(new File(prefPaneContents, "Resources/SetupBuilderOSXPrefPane.app").toPath(), new File(prefPaneContents, "Resources/"+ applicationName +".app").toPath(),  java.nio.file.StandardCopyOption.REPLACE_EXISTING );
+		Files.move(new File(prefPaneContents, "MacOS/SetupBuilderOSXPrefPane").toPath(), new File( prefPaneContents, "MacOS/"+ displayName ).toPath(),  java.nio.file.StandardCopyOption.REPLACE_EXISTING );
+		Files.move(new File(prefPaneContents, "Resources/SetupBuilderOSXPrefPane.app").toPath(), new File(prefPaneContents, "Resources/"+ displayName +".app").toPath(),  java.nio.file.StandardCopyOption.REPLACE_EXISTING );
 		System.out.println("Unpacked the Preference Pane to: " + prefPaneContents.getAbsolutePath() );
 
 		// Make executable
-		setApplicationFilePermissions( new File(prefPaneContents, "Resources/"+ applicationName +".app/Contents/MacOS/applet") );
+		setApplicationFilePermissions( new File(prefPaneContents, "Resources/"+ displayName +".app/Contents/MacOS/applet") );
     	
 		// Rename prefPane
 		Files.move(new File(resourcesOutput, "SetupBuilderOSXPrefPane.prefPane").toPath(), prefPaneLocation.toPath(),  java.nio.file.StandardCopyOption.REPLACE_EXISTING );
@@ -238,15 +237,15 @@ public class OSXApplicationBuilder extends AbstractBuilder<Dmg> {
 		File prefPanePLIST = new File(prefPaneLocation, "Contents/Info.plist");
 		setPlistProperty( prefPanePLIST, ":CFBundleIdentifier", setup.getMainClass() + ".prefPane" );
 		setPlistProperty( prefPanePLIST, ":CFBundleName", displayName + " Preference Pane" );
-		setPlistProperty( prefPanePLIST, ":CFBundleExecutable", applicationName );
+		setPlistProperty( prefPanePLIST, ":CFBundleExecutable", displayName );
 		setPlistProperty( prefPanePLIST, ":NSPrefPaneIconLabel", displayName );
 
-		setPlistProperty( prefPanePLIST, ":CFBundleExecutable", applicationName );
+		setPlistProperty( prefPanePLIST, ":CFBundleExecutable", displayName );
 		
 		File servicePLIST = new File(prefPaneLocation, "Contents/Resources/service.plist");
 		setPlistProperty( servicePLIST, ":Name", displayName );
 		setPlistProperty( servicePLIST, ":Label", setup.getMainClass() );
-		setPlistProperty( servicePLIST, ":Program", "/Library/" + applicationName + "/" + applicationName + ".app/Contents/MacOS/" + setup.getBaseName() );
+		setPlistProperty( servicePLIST, ":Program", "/Library/" + displayName + "/" + displayName + ".app/Contents/MacOS/" + setup.getAppIdentifier() );
 		setPlistProperty( servicePLIST, ":Description", setup.getServices().get(0).getDescription() );
 		setPlistProperty( servicePLIST, ":Version", setup.getVersion() );
 	}

--- a/src/com/inet/gradle/setup/msi/MsiBuilder.java
+++ b/src/com/inet/gradle/setup/msi/MsiBuilder.java
@@ -93,7 +93,7 @@ class MsiBuilder extends AbstractBuilder<Msi> {
 
             // signing and moving the final msi file
             signTool( mui );
-            Files.move( mui.toPath(), new File( setup.getDestinationDir(), setup.getSetupName() + ".msi" ).toPath(), StandardCopyOption.REPLACE_EXISTING );
+            Files.move( mui.toPath(), new File( setup.getDestinationDir(), setup.getDownloadFileName() + ".msi" ).toPath(), StandardCopyOption.REPLACE_EXISTING );
         } catch( RuntimeException ex ) {
             throw ex;
         } catch( Exception ex ) {
@@ -136,7 +136,7 @@ class MsiBuilder extends AbstractBuilder<Msi> {
      * @return the generated msi file
      */
     private File light( MsiLanguages language ) {
-        File out = new File( buildDir, setup.getSetupName() + '_' + language.getCulture() + ".msi" );
+        File out = new File( buildDir, setup.getDownloadFileName() + '_' + language.getCulture() + ".msi" );
         ArrayList<String> parameters = new ArrayList<>();
         parameters.add( "-nologo" );
         parameters.add( "-sice:ICE60" ); // accept *.ttf files to install in the install directory
@@ -294,7 +294,7 @@ class MsiBuilder extends AbstractBuilder<Msi> {
      * @return the xml file
      */
     private File getWxsFile() {
-        return new File( buildDir, setup.getSetupName() + ".wxs" );
+        return new File( buildDir, setup.getDownloadFileName() + ".wxs" );
     }
 
     /**

--- a/src/com/inet/gradle/setup/msi/WxsFileBuilder.java
+++ b/src/com/inet/gradle/setup/msi/WxsFileBuilder.java
@@ -485,9 +485,9 @@ class WxsFileBuilder extends XmlFileBuilder<Msi> {
         File prunmgr = ResourceUtils.extract( getClass(), "x86/prunmgr.exe", buildDir );
 
         for( Service service : services ) {
-            String name = service.getName();
+            String name = service.getDisplayName();
             String id = id( name.replace( '-', '_' ) ) + "_service";
-            String exe = service.getBaseName().replace( '\\', '/' ) + ".exe";
+            String exe = service.getServiceID().replace( '\\', '/' ) + ".exe";
             int idx = exe.lastIndexOf( '/' );
             String subdir = exe.substring( 0, idx + 1 );
 
@@ -604,9 +604,9 @@ class WxsFileBuilder extends XmlFileBuilder<Msi> {
 
         for( DesktopStarter starter : starters ) {
             Element component = getShortcutComponent( starter, product );
-            String id = id( starter.getLocation() + "_" + starter.getName() );
+            String id = id( starter.getLocation() + "_" + starter.getDisplayName() );
             Element shortcut = getOrCreateChildById( component, "Shortcut", id );
-            addAttributeIfNotExists( shortcut, "Name", starter.getName() );
+            addAttributeIfNotExists( shortcut, "Name", starter.getDisplayName() );
             addAttributeIfNotExists( shortcut, "Description", starter.getDescription() );
 
             addAttributeIfNotExists( shortcut, "WorkingDirectory", getWoringDirID( starter, installDir ) );
@@ -619,7 +619,7 @@ class WxsFileBuilder extends XmlFileBuilder<Msi> {
                     iconID = ICON_ID;
                 } else {
                     File iconFile = ImageFactory.getImageFile( task.getProject(), starter.getIcons(), buildDir, "ico" );
-                    iconID = id( starter.getName() + ".ico" );
+                    iconID = id( starter.getDisplayName() + ".ico" );
                     Element icon = getOrCreateChildById( product, "Icon", iconID );
                     addAttributeIfNotExists( icon, "SourceFile", iconFile.getAbsolutePath() );
                 }

--- a/src/com/inet/gradle/setup/rpm/RpmBuilder.java
+++ b/src/com/inet/gradle/setup/rpm/RpmBuilder.java
@@ -114,7 +114,7 @@ public class RpmBuilder extends AbstractBuilder<Rpm> {
         if(starter != null ) {
         	workingDir = starter.getWorkDir();
         }	
-    	String serviceUnixName = service.getName().toLowerCase().replace( ' ', '-' );
+    	String serviceUnixName = service.getServiceID();
         String mainJarPath;
         
         		
@@ -220,7 +220,7 @@ public class RpmBuilder extends AbstractBuilder<Rpm> {
      */
     // share
     private void setupStarter( DesktopStarter starter ) throws IOException {
-        String unixName = starter.getName().toLowerCase().replace( ' ', '-' );
+        String unixName = starter.getExecutable();
         String consoleStarterPath = "/usr/bin/" + unixName;
         try (FileWriter fw = new FileWriter( createFile( "BUILD" + consoleStarterPath, true ) )) {
             fw.write( "#!/bin/bash\n" );
@@ -241,7 +241,7 @@ public class RpmBuilder extends AbstractBuilder<Rpm> {
         }
         try (FileWriter fw = new FileWriter( createFile( "BUILD/usr/share/applications/" + unixName + ".desktop", false ) )) {
             fw.write( "[Desktop Entry]\n" );
-            fw.write( "Name=" + starter.getName() + "\n" );
+            fw.write( "Name=" + starter.getDisplayName() + "\n" );
             fw.write( "Comment=" + starter.getDescription().replace( '\n', ' ' ) + "\n" );
             fw.write( "Exec=" + consoleStarterPath + " %F\n" );
             fw.write( "Icon=" + unixName + "\n" );
@@ -291,7 +291,7 @@ public class RpmBuilder extends AbstractBuilder<Rpm> {
         command.add( "-v" );
         command.add( "--clean" );
         command.add( "--define=_topdir " + buildDir.getAbsolutePath() );
-        command.add( "SPECS/" + setup.getBaseName() + ".spec" );
+        command.add( "SPECS/" + setup.getAppIdentifier() + ".spec" );
         exec( command );
     }
 

--- a/src/com/inet/gradle/setup/rpm/RpmControlFileBuilder.java
+++ b/src/com/inet/gradle/setup/rpm/RpmControlFileBuilder.java
@@ -92,7 +92,7 @@ class RpmControlFileBuilder {
 		OutputStreamWriter controlWriter = null;
 
 		try {
-			File spec = new File(buildDir, setup.getBaseName() + ".spec");
+			File spec = new File(buildDir, setup.getAppIdentifier() + ".spec");
 			fileoutput = new FileOutputStream(spec);
 			controlWriter = new OutputStreamWriter(fileoutput, "UTF-8");
 			
@@ -300,8 +300,8 @@ class RpmControlFileBuilder {
 		if(release == null || release.length() == 0) {
 			release = "1";
 		}
-		controlWriter.write("cp ../SRPMS/" + setup.getBaseName() + "-" + setup.getVersion() + "-" + release + ".src.rpm " + setup.getDestinationDir().getAbsolutePath() + NEWLINE);
-		controlWriter.write("mv -f ../RPMS/noarch/" + setup.getBaseName() + "-" + setup.getVersion() + "-" + release + ".noarch.rpm " + setup.getDestinationDir().getAbsolutePath() + "/" + setup.getBaseName() + "-" + setup.getVersion() + ".rpm" + NEWLINE);
+		controlWriter.write("cp ../SRPMS/" + setup.getAppIdentifier() + "-" + setup.getVersion() + "-" + release + ".src.rpm " + setup.getDestinationDir().getAbsolutePath() + NEWLINE);
+		controlWriter.write("mv -f ../RPMS/noarch/" + setup.getAppIdentifier() + "-" + setup.getVersion() + "-" + release + ".noarch.rpm " + setup.getDestinationDir().getAbsolutePath() + "/" + setup.getAppIdentifier() + "-" + setup.getVersion() + ".rpm" + NEWLINE);
 		ArrayList<String> cleans = rpm.getClean();
 		for (String clean : cleans) {
 			controlWriter.write(clean + NEWLINE);	
@@ -539,7 +539,7 @@ class RpmControlFileBuilder {
 	 */
 	private void putName(OutputStreamWriter controlWriter)
 			throws IOException {
-		String packages = setup.getBaseName();
+		String packages = setup.getAppIdentifier();
 		if(packages == null || packages.length() == 0) {
 			throw new RuntimeException("No package declared in the setup configuration.");
 		} else {


### PR DESCRIPTION
Services now have an identifier and a display name. DesktopStarters should only have a display name.

The SetupBuilder itself only needs the basic identifier and application name. Both can be derived. But it also has a setupName to automatically add the version number to the identifier if no other name is configured.