### PR TITLE
starting with java 11, the jdk no longer has a subdirectory "jre"

### DIFF
--- a/src/com/inet/gradle/appbundler/OSXNotarize.java
+++ b/src/com/inet/gradle/appbundler/OSXNotarize.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.gradle.api.internal.changedetection.state.IntegerValueSnapshot;
 import org.gradle.api.internal.file.FileResolver;
 
 import com.inet.gradle.appbundler.utils.xmlwise.Plist;

--- a/src/com/inet/gradle/setup/msi/WxsFileBuilder.java
+++ b/src/com/inet/gradle/setup/msi/WxsFileBuilder.java
@@ -489,9 +489,25 @@ class WxsFileBuilder extends XmlFileBuilder<Msi> {
         }
         Pattern jreMatcher = Pattern.compile("\\Aj(re|dk)-?(1\\.)?"+Pattern.quote(jre));
         List<File> versions = Arrays.asList(
-        	parent.listFiles(file->file.isDirectory() && jreMatcher.matcher(file.getName()).find())
+        	parent.listFiles(file->jreMatcher.matcher(file.getName()).find() && isValidJRE(file))
         );
         return versions;
+    }
+
+    /**
+     * Checks if a specific directory is valid as a jre.  if it's a jdk, make sure a jre exists.
+     * @param jreDir the jre directory that is being checked for validity
+     * @return returns true if there is a valid jre here
+     */
+    private static boolean isValidJRE( File jreDir ) {
+        if( !jreDir.isDirectory() ) {
+            return false;
+        }
+        if( jreDir.getName().startsWith( "jdk" ) && !new File( jreDir, "jre" ).isDirectory() ) {
+            //starting with java 11, the jdk no longer has a subdirectory "jre"
+            return false;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
starting with java 11, the jdk no longer has a subdirectory "jre"

you'll need an actual jre

this fixes NullPointerException

also remove unused import to class that no longer exists.