### PR TITLE
allow user to skip validation.

### DIFF
--- a/src/com/inet/gradle/setup/msi/Msi.java
+++ b/src/com/inet/gradle/setup/msi/Msi.java
@@ -67,7 +67,9 @@ public class Msi extends AbstractSetupTask {
 
     private List<MsiLocalizedResource> i18n               = new ArrayList<>();
 
-    private List<File>               externals = new ArrayList<>();
+    private List<File>                 externals = new ArrayList<>();
+
+    private boolean                    skipValidation = false;
 
     /**
      * Create a new instance.
@@ -513,5 +515,21 @@ public class Msi extends AbstractSetupTask {
      */
     public List<File> getExternals() {
         return externals;
+    }
+
+    /**
+     * Returns if the skipValidation is requested
+     * @return the skipValidation
+     */
+    public boolean isSkipValidation() {
+        return skipValidation;
+    }
+
+    /**
+     * Set that the skipValidation is requested
+     * @param skipValidation the skipValidation to set
+     */
+    public void setSkipValidation( boolean skipValidation ) {
+        this.skipValidation = skipValidation;
     }
 }

--- a/src/com/inet/gradle/setup/msi/MsiBuilder.java
+++ b/src/com/inet/gradle/setup/msi/MsiBuilder.java
@@ -221,6 +221,11 @@ class MsiBuilder extends AbstractBuilder<Msi,SetupBuilder> {
             parameters.add( "-dWixUILicenseRtf=\"" + localizedRtfFile.getAbsolutePath() + "\"" );
         }
 
+        // Check if we should skip msi validation
+        if ( task.isSkipValidation() ) {
+            parameters.add( "-sval" );
+        }
+
         parameters.add( "*.wixobj" );
         callWixTool( "light.exe", parameters );
         return out;

--- a/src/com/inet/gradle/setup/msi/sdk/wilangid.vbs
+++ b/src/com/inet/gradle/setup/msi/sdk/wilangid.vbs
@@ -17,7 +17,8 @@ Const msiViewModifyAssign         = 3
 Const msiViewModifyReplace        = 4
 Const msiViewModifyDelete         = 6
 
-Dim argCount:argCount = Wscript.Arguments.Count
+Dim argCount
+argCount = Wscript.Arguments.Count
 If argCount > 0 Then If InStr(1, Wscript.Arguments(0), "?", vbTextCompare) > 0 Then argCount = 0
 If (argCount = 0) Then
 	message = "Windows Installer utility to manage language and codepage values for a package." &_

--- a/src/com/inet/gradle/setup/msi/sdk/wisubstg.vbs
+++ b/src/com/inet/gradle/setup/msi/sdk/wisubstg.vbs
@@ -21,7 +21,8 @@ Const ForWriting = 2
 Const TristateTrue = -1
 
 ' Check arg count, and display help if argument not present or contains ?
-Dim argCount:argCount = Wscript.Arguments.Count
+Dim argCount
+argCount = Wscript.Arguments.Count
 If argCount > 0 Then If InStr(1, Wscript.Arguments(0), "?", vbTextCompare) > 0 Then argCount = 0
 If (argCount = 0) Then
 	Wscript.Echo "Windows Installer database substorage managment utility" &_


### PR DESCRIPTION
allow user to skip validation.

this helps when running in wine, since light.exe fails in wine without skipping validation.

also change the vbscript files to work in wine (declaring and setting the variables in one line does not work)