### PR TITLE
Fix API that accepts closures so it an be used from Kotlin

### DIFF
--- a/src/com/inet/gradle/appbundler/AppBundlerGradleTask.java
+++ b/src/com/inet/gradle/appbundler/AppBundlerGradleTask.java
@@ -18,10 +18,10 @@ package com.inet.gradle.appbundler;
 
 import java.io.File;
 
+import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.util.ConfigureUtil;
 
 import com.inet.gradle.setup.abstracts.AbstractTask;
 
@@ -75,11 +75,12 @@ public class AppBundlerGradleTask extends AbstractTask {
     /**
      * Set the needed information for signing the setup.
      * 
-     * @param closure the data for signing
+     * @param action the data for signing
      */
-    public void codeSign( Closure<AppBundler> closure ) {
+    public void codeSign( Action<? super OSXCodeSign<? super AppBundlerGradleTask,? super AppBundler>> action ) {
         ProjectInternal project = (ProjectInternal)getProject();
-        codeSign = ConfigureUtil.configure( closure, new OSXCodeSign<AppBundlerGradleTask,AppBundler>(this, project.getFileResolver()) );
+        codeSign = new OSXCodeSign<>(this, project.getFileResolver());
+        action.execute(codeSign);
     }
 
     /**

--- a/src/com/inet/gradle/appbundler/OSXCodeSign.java
+++ b/src/com/inet/gradle/appbundler/OSXCodeSign.java
@@ -6,9 +6,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 
+import org.gradle.api.Action;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.util.ConfigureUtil;
 
 import com.inet.gradle.setup.abstracts.AbstractBuilder;
 import com.inet.gradle.setup.abstracts.AbstractSetupBuilder;
@@ -331,11 +331,12 @@ public class OSXCodeSign<T extends AbstractTask, S extends AbstractSetupBuilder>
 
     /**
      * Set the notarization information
-     * @param closure the notarization information
+     * @param action the notarization information
      */
-    public void notarization( Closure<OSXNotarize<T, S>> closure ) {
+    public void notarization( Action<? super OSXNotarize<? super T, ? super S>> action ) {
         ProjectInternal project = (ProjectInternal)task.getProject();
-        this.notarization = ConfigureUtil.configure( closure, new OSXNotarize<T, S>(getTask(), project.getFileResolver(), this) );
+        this.notarization = new OSXNotarize<T, S>(getTask(), project.getFileResolver(), this);
+        action.execute(this.notarization);
     }
 
     /**

--- a/src/com/inet/gradle/setup/SetupBuilder.java
+++ b/src/com/inet/gradle/setup/SetupBuilder.java
@@ -20,8 +20,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.util.ConfigureUtil;
 
 import com.inet.gradle.setup.abstracts.AbstractSetupBuilder;
 import com.inet.gradle.setup.abstracts.DesktopStarter;
@@ -127,10 +127,11 @@ public class SetupBuilder extends AbstractSetupBuilder implements SetupSources {
     /**
      * Set a command that run after the installer.
      *
-     * @param closure the command
+     * @param action the command
      */
-    public void runAfter( Closure<?> closure ) {
-        runAfter = ConfigureUtil.configure( closure, new DesktopStarter( this ) );
+    public void runAfter( Action<? super DesktopStarter> action ) {
+        runAfter = new DesktopStarter( this );
+        action.execute(runAfter);
     }
 
     /**
@@ -155,19 +156,21 @@ public class SetupBuilder extends AbstractSetupBuilder implements SetupSources {
     /**
      * Set a command that run run before the uninstaller.
      *
-     * @param closue the command
+     * @param action the command
      */
-    public void runBeforeUninstall( Closure<DesktopStarter> closue ) {
-        runBeforeUninstall = ConfigureUtil.configure( closue, new DesktopStarter( this ) );
+    public void runBeforeUninstall( Action<? super DesktopStarter> action ) {
+        runBeforeUninstall = new DesktopStarter( this );
+        action.execute(runBeforeUninstall);
     }
 
     /**
      * Register a service.
      *
-     * @param closue the closure of the service definition
+     * @param action the closure of the service definition
      */
-    public void service( Closure<Service> closue ) {
-        Service service = ConfigureUtil.configure( closue, new Service( this ) );
+    public void service( Action<? super Service> action ) {
+        Service service = new Service( this );
+        action.execute(service);
         services.add( service );
     }
 
@@ -183,10 +186,11 @@ public class SetupBuilder extends AbstractSetupBuilder implements SetupSources {
     /**
      * Register a desktop starter.
      *
-     * @param closue the closure of the desktop starter's definition
+     * @param action the closure of the desktop starter's definition
      */
-    public void desktopStarter( Closure<?> closue ) {
-        DesktopStarter service = ConfigureUtil.configure( closue, new DesktopStarter( this ) );
+    public void desktopStarter( Action<? super DesktopStarter> action ) {
+        DesktopStarter service = new DesktopStarter( this );
+        action.execute(service);
         desktopStarters.add( service );
     }
 

--- a/src/com/inet/gradle/setup/abstracts/DesktopStarter.java
+++ b/src/com/inet/gradle/setup/abstracts/DesktopStarter.java
@@ -19,8 +19,8 @@ package com.inet.gradle.setup.abstracts;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.util.ConfigureUtil;
 
 import groovy.lang.Closure;
 
@@ -114,10 +114,11 @@ public class DesktopStarter extends ProtocolHandler {
     /**
      * Register a file extensions.
      *
-     * @param closue document type
+     * @param action document type
      */
-    public void documentType( Closure<?> closue ) {
-        DocumentType doc = ConfigureUtil.configure( closue, new DocumentType( setup ) );
+    public void documentType( Action<? super DocumentType> action ) {
+        DocumentType doc = new DocumentType( setup );
+        action.execute(doc);
         if( doc.getFileExtension() == null || doc.getFileExtension().size() == 0 ) {
             throw new GradleException( "The documentType has to contain at least one file extension." );
         }

--- a/src/com/inet/gradle/setup/dmg/Dmg.java
+++ b/src/com/inet/gradle/setup/dmg/Dmg.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.tools.ant.types.FileSet;
+import org.gradle.api.Action;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.util.ConfigureUtil;
 
 import com.inet.gradle.appbundler.OSXCodeSign;
 import com.inet.gradle.setup.SetupBuilder;
@@ -254,11 +254,12 @@ public class Dmg extends AbstractUnixSetupTask {
     /**
      * Set the needed information for signing the setup.
      *
-     * @param closure the data for signing
+     * @param action the data for signing
      */
-    public void setCodeSign( Closure<OSXCodeSign<Dmg, SetupBuilder>> closure ) {
+    public void setCodeSign( Action<? super OSXCodeSign<? super Dmg,? super SetupBuilder>> action ) {
         ProjectInternal project = (ProjectInternal)getProject();
-        codeSign = ConfigureUtil.configure( closure, new OSXCodeSign<Dmg, SetupBuilder>( this, project.getFileResolver() ) );
+        codeSign = new OSXCodeSign<>(this, project.getFileResolver());
+        action.execute(codeSign);
     }
 
     /**
@@ -385,10 +386,12 @@ public class Dmg extends AbstractUnixSetupTask {
     /**
      * Set a preferences link
      * 
-     * @param link the link
+     * @param action the link
      */
-    public void preferencesLink( Object link ) {
-        preferencesLink.add( ConfigureUtil.configure( (Closure<?>)link, new PreferencesLink() ) );
+    public void preferencesLink( Action<? super PreferencesLink> action ) {
+        final PreferencesLink link = new PreferencesLink();
+        action.execute(link);
+        preferencesLink.add(link);
     }
 
     /**

--- a/src/com/inet/gradle/setup/msi/Msi.java
+++ b/src/com/inet/gradle/setup/msi/Msi.java
@@ -25,13 +25,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
-import org.gradle.util.ConfigureUtil;
 
 import com.inet.gradle.setup.abstracts.AbstractSetupTask;
 import com.inet.gradle.setup.util.ResourceUtils;
@@ -219,10 +219,11 @@ public class Msi extends AbstractSetupTask {
     /**
      * Set the needed information for signing the setup.
      *
-     * @param closue the data for signing
+     * @param action the data for signing
      */
-    public void signTool( Closure<SignTool> closue ) {
-        signTool = ConfigureUtil.configure( closue, new SignTool() );
+    public void signTool( Action<? super SignTool> action ) {
+        signTool = new SignTool();
+        action.execute(signTool);
     }
 
     /**
@@ -352,10 +353,11 @@ public class Msi extends AbstractSetupTask {
     /**
      * Register a lauch4j configuration. Every configuration create an *.exe file with the given settings.
      *
-     * @param closue the closure of the launch4j definition
+     * @param action the closure of the launch4j definition
      */
-    public void launch4j( Closure<Launch4j> closue ) {
-        Launch4j launcher = ConfigureUtil.configure( closue, new Launch4j( getSetupBuilder() ) );
+    public void launch4j( Action<Launch4j> action ) {
+        Launch4j launcher = new Launch4j( getSetupBuilder() );
+        action.execute(launcher);
         launch4j.add( launcher );
     }
 


### PR DESCRIPTION
Several APIs used Closure<V> as if V was closure argument.
But instead, V is actually closure return type.

This commit replaces all user-facing APIs that accepts Closure to instead accept Action<T>

----

Note that there is still a couple of places where Closure is used in the code. I'm not sure how to fix them properly.