### PR TITLE
Add ability to specify additional extensions if required by Externals…

### DIFF
--- a/src/com/inet/gradle/setup/msi/Msi.java
+++ b/src/com/inet/gradle/setup/msi/Msi.java
@@ -67,6 +67,8 @@ public class Msi extends AbstractSetupTask {
 
     private List<String>               preGUI             = new ArrayList<String>();
 
+    private List<String>               wixextensions      = new ArrayList<String>();
+    
     // Will generate a checkbox.
     private boolean                    runAfterIsOptional = false;
 
@@ -576,6 +578,29 @@ public class Msi extends AbstractSetupTask {
     @InputFiles
     public List<File> getExternals() {
         return externals;
+    }
+    
+    /**
+     * Sets list of wix extension dll's
+     * @param wixextensions extension dll's
+     * @return this Msi instance
+     */
+    public Msi setWixExtensions(Iterable<String> wixextensions) {
+        this.wixextensions.clear();
+        for (String wixextension : wixextensions) {
+            this.wixextensions.add(wixextension);
+        }
+        return this;
+    }
+
+    
+    
+    /**
+     * @return registered extensions
+     */
+    @Input
+    public List<String> getWixExtensions() {
+        return wixextensions;
     }
 
     /**

--- a/src/com/inet/gradle/setup/msi/MsiBuilder.java
+++ b/src/com/inet/gradle/setup/msi/MsiBuilder.java
@@ -180,6 +180,10 @@ class MsiBuilder extends AbstractBuilder<Msi,SetupBuilder> {
         for(File external : task.getExternals()){
             parameters.add( external.getAbsolutePath() );
         }
+        for(String extension : task.getWixExtensions()){
+        	parameters.add( "-ext" );
+            parameters.add( extension );
+        }
         parameters.add( "-ext" );
         parameters.add( "WixUtilExtension" );
 
@@ -198,6 +202,10 @@ class MsiBuilder extends AbstractBuilder<Msi,SetupBuilder> {
         ArrayList<String> parameters = new ArrayList<>();
         parameters.add( "-nologo" );
         parameters.add( "-sice:ICE60" ); // accept *.ttf files to install in the install directory
+        for(String extension : task.getWixExtensions()){
+        	parameters.add( "-ext" );
+            parameters.add( extension );
+        }
         parameters.add( "-ext" );
         parameters.add( "WixUIExtension" );
         parameters.add( "-ext" );


### PR DESCRIPTION
…/Templates

When using external fragments or wxs templates dependencies on additional extensions can be introduced.  This would allow us to add those extensions to the candle and light command lines.