### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ System Requirements
 | Linux     | Lintian, FakeRoot <br> on Ubuntu: `apt-get install lintian fakeroot` |
 | Linux     | dpkg for creating Debian packages: `apt-get install dpkg`         |
 | Linux     | rpm for creating RPM packages: `apt-get install rpm`              |
+| MacOS     | hdiutil, only available on Mac                                       |
 
 Plugin and Gradle Version
 ----


### PR DESCRIPTION
The absence of an entry for MacOS in the OS-specific system requirements looks deceptively as if setupbuilder could create .dmg on any platform.

I guess that was the reason for the absence was that hdiutils is available on all Macs? Still makes it a dependency worth mentioning for those who aren't on a Mac (or want to build on some build farm)