### PR TITLE
add recursive functionality for finding INSTALLDIR

### DIFF
--- a/src/com/inet/gradle/setup/msi/WxsFileBuilder.java
+++ b/src/com/inet/gradle/setup/msi/WxsFileBuilder.java
@@ -152,7 +152,10 @@ class WxsFileBuilder extends XmlFileBuilder<Msi> {
         Element directory = getOrCreateChildById( product, "Directory", "TARGETDIR" );
         addAttributeIfNotExists( directory, "Name", "SourceDir" );
         Element programFiles = getOrCreateChildById( directory, "Directory", task.is64Bit() ? "ProgramFiles64Folder" : "ProgramFilesFolder" );
-        Element appDirectory = getOrCreateChildById( programFiles, "Directory", "INSTALLDIR" );
+        Element appDirectory = getChildRecursive(programFiles, "Directory", "Id", "INSTALLDIR");
+        if( appDirectory == null ) {
+            appDirectory = getOrCreateChildById( programFiles, "Directory", "INSTALLDIR" );
+        }
         addAttributeIfNotExists( appDirectory, "Name", setup.getApplication() );
 
         //Files

--- a/src/com/inet/gradle/setup/util/XmlFileBuilder.java
+++ b/src/com/inet/gradle/setup/util/XmlFileBuilder.java
@@ -214,7 +214,7 @@ public class XmlFileBuilder<T extends AbstractSetupTask> {
 
         Element res = null;
         for( Node child = first; child != null && res == null; child = child.getNextSibling() ) {
-            res = getChildRecursive(child, name, key, value)
+            res = getChildRecursive(child, name, key, value);
         }
         return (Element)res;
     }

--- a/src/com/inet/gradle/setup/util/XmlFileBuilder.java
+++ b/src/com/inet/gradle/setup/util/XmlFileBuilder.java
@@ -196,4 +196,27 @@ public class XmlFileBuilder<T extends AbstractSetupTask> {
         return child;
     }
 
+    /**
+     * Get a child element (recursive search).
+     *
+     * @param parent the parent node in which we search and create
+     * @param name The tag name of the element
+     * @param key the name of an attribute, can't be null
+     * @param value the value, can be null for not existing
+     * @return the create of find Element
+     */
+    public Element getChildRecursive( Node parent, String name, String key, String value) {
+        if( name.equals( parent.getNodeName() ) ) {
+            if( Objects.equals( value, ((Element)parent).getAttribute( key ) ) || (value == null && !((Element)parent).hasAttribute( key )) ) {
+                return (Element)parent;
+            }
+        }
+
+        Element res = null;
+        for( Node child = first; child != null && res == null; child = child.getNextSibling() ) {
+            res = getChildExhaustive(child, name, key, value)
+        }
+        return (Element)res;
+    }
+
 }

--- a/src/com/inet/gradle/setup/util/XmlFileBuilder.java
+++ b/src/com/inet/gradle/setup/util/XmlFileBuilder.java
@@ -214,7 +214,7 @@ public class XmlFileBuilder<T extends AbstractSetupTask> {
 
         Element res = null;
         for( Node child = first; child != null && res == null; child = child.getNextSibling() ) {
-            res = getChildExhaustive(child, name, key, value)
+            res = getChildRecursive(child, name, key, value)
         }
         return (Element)res;
     }

--- a/src/com/inet/gradle/setup/util/XmlFileBuilder.java
+++ b/src/com/inet/gradle/setup/util/XmlFileBuilder.java
@@ -203,7 +203,7 @@ public class XmlFileBuilder<T extends AbstractSetupTask> {
      * @param name The tag name of the element
      * @param key the name of an attribute, can't be null
      * @param value the value, can be null for not existing
-     * @return the create of find Element
+     * @return the foudn element or null
      */
     public Element getChildRecursive( Node parent, String name, String key, String value) {
         if( name.equals( parent.getNodeName() ) ) {

--- a/src/com/inet/gradle/setup/util/XmlFileBuilder.java
+++ b/src/com/inet/gradle/setup/util/XmlFileBuilder.java
@@ -211,7 +211,8 @@ public class XmlFileBuilder<T extends AbstractSetupTask> {
                 return (Element)parent;
             }
         }
-
+        
+        Node first = parent.getFirstChild();
         Element res = null;
         for( Node child = first; child != null && res == null; child = child.getNextSibling() ) {
             res = getChildRecursive(child, name, key, value);


### PR DESCRIPTION
Currently the installdir may only be placed under the program files folder. This PR allows users to place the installation directory in nested folders when using a template wix file. 